### PR TITLE
feat: add author `title` field

### DIFF
--- a/example/astro.config.mjs
+++ b/example/astro.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
   integrations: [
     starlightBlog({
       authors: {
-        hideoo: { name: 'HiDeoo', title: 'Starlight MVP', picture: '/hideoo.png', url: 'https://hideoo.dev' },
+        hideoo: { name: 'HiDeoo', title: 'Starlight Legend', picture: '/hideoo.png', url: 'https://hideoo.dev' },
       },
     }),
     starlight({

--- a/example/astro.config.mjs
+++ b/example/astro.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
   integrations: [
     starlightBlog({
       authors: {
-        hideoo: { name: 'HiDeoo', picture: '/hideoo.png', url: 'https://hideoo.dev' },
+        hideoo: { name: 'HiDeoo', title: 'Starlight MVP', picture: '/hideoo.png', url: 'https://hideoo.dev' },
       },
     }),
     starlight({

--- a/example/astro.config.mjs
+++ b/example/astro.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
   integrations: [
     starlightBlog({
       authors: {
-        hideoo: { name: 'HiDeoo', title: 'Starlight Legend', picture: '/hideoo.png', url: 'https://hideoo.dev' },
+        hideoo: { name: 'HiDeoo', title: 'Starlight Aficionado', picture: '/hideoo.png', url: 'https://hideoo.dev' },
       },
     }),
     starlight({

--- a/example/src/content/docs/guides/authors.md
+++ b/example/src/content/docs/guides/authors.md
@@ -9,7 +9,7 @@ Authors can be defined in a blog post using the `authors` frontmatter property a
 ```yaml
 authors:
   name: HiDeoo
-  title: Starlight Legend
+  title: Starlight Aficionado
   picture: https://avatars.githubusercontent.com/u/494699
   url: https://hideoo.dev
 ```
@@ -19,7 +19,7 @@ Multiple authors can be defined using an array:
 ```yaml
 authors:
   - name: HiDeoo
-    title: Starlight Legend
+    title: Starlight Aficionado
     picture: https://avatars.githubusercontent.com/u/494699
     url: https://hideoo.dev
   - name: Ghost
@@ -36,7 +36,7 @@ starlightBlog({
   authors: {
     hideoo: {
       name: 'HiDeoo',
-      title: 'Starlight Legend',
+      title: 'Starlight Aficionado',
       picture: '/hideoo.png', // Images in the `public` directory are supported.
       url: 'https://hideoo.dev',
     },

--- a/example/src/content/docs/guides/authors.md
+++ b/example/src/content/docs/guides/authors.md
@@ -9,6 +9,7 @@ Authors can be defined in a blog post using the `authors` frontmatter property a
 ```yaml
 authors:
   name: HiDeoo
+  title: Starlight Legend
   picture: https://avatars.githubusercontent.com/u/494699
   url: https://hideoo.dev
 ```
@@ -18,6 +19,7 @@ Multiple authors can be defined using an array:
 ```yaml
 authors:
   - name: HiDeoo
+    title: Starlight Legend
     picture: https://avatars.githubusercontent.com/u/494699
     url: https://hideoo.dev
   - name: Ghost
@@ -34,6 +36,7 @@ starlightBlog({
   authors: {
     hideoo: {
       name: 'HiDeoo',
+      title: 'Starlight Legend',
       picture: '/hideoo.png', // Images in the `public` directory are supported.
       url: 'https://hideoo.dev',
     },

--- a/packages/starlight-blog/README.md
+++ b/packages/starlight-blog/README.md
@@ -131,7 +131,7 @@ Authors can be defined in a blog post using the `authors` frontmatter property a
 ```yaml
 authors:
   name: HiDeoo
-  title: Starlight Legend
+  title: Starlight Aficionado
   picture: https://avatars.githubusercontent.com/u/494699
   url: https://hideoo.dev
 ```
@@ -141,7 +141,7 @@ Multiple authors can be defined using an array:
 ```yaml
 authors:
   - name: HiDeoo
-    title: Starlight Legend
+    title: Starlight Aficionado
     picture: https://avatars.githubusercontent.com/u/494699
     url: https://hideoo.dev
   - name: Ghost
@@ -156,7 +156,7 @@ starlightBlog({
   authors: {
     hideoo: {
       name: 'HiDeoo',
-      title: 'Starlight Legend',
+      title: 'Starlight Aficionado',
       picture: '/hideoo.png', // Images in the `public` directory are supported.
       url: 'https://hideoo.dev',
     },

--- a/packages/starlight-blog/README.md
+++ b/packages/starlight-blog/README.md
@@ -131,6 +131,7 @@ Authors can be defined in a blog post using the `authors` frontmatter property a
 ```yaml
 authors:
   name: HiDeoo
+  title: Starlight Legend
   picture: https://avatars.githubusercontent.com/u/494699
   url: https://hideoo.dev
 ```
@@ -140,6 +141,7 @@ Multiple authors can be defined using an array:
 ```yaml
 authors:
   - name: HiDeoo
+    title: Starlight Legend
     picture: https://avatars.githubusercontent.com/u/494699
     url: https://hideoo.dev
   - name: Ghost
@@ -154,6 +156,7 @@ starlightBlog({
   authors: {
     hideoo: {
       name: 'HiDeoo',
+      title: 'Starlight Legend',
       picture: '/hideoo.png', // Images in the `public` directory are supported.
       url: 'https://hideoo.dev',
     },

--- a/packages/starlight-blog/components/Author.astro
+++ b/packages/starlight-blog/components/Author.astro
@@ -12,24 +12,38 @@ const Element = isLink ? 'a' : 'div'
 ---
 
 <Element href={isLink ? author.url : undefined} class="author flex">
-  {author.picture ? <img alt={author.name} src={author.picture} /> : null}
-  {author.name}
+  {author.picture && <img alt={author.name} src={author.picture} />}
+  <div class="flex text">
+    <div class="name">{author.name}</div>
+    {author.title && <div class="title">{author.title}</div>}
+  </div>
 </Element>
 
 <style>
   .author {
     align-items: center;
-    font-weight: 600;
     gap: 0.5rem;
+    line-height: var(--sl-line-height-headings);
     text-decoration: none;
   }
 
-  .author[href] {
+  .text {
+    flex-direction: column;
+  }
+
+  .name {
+    font-size: var(--sl-text-base);
+    font-weight: 600;
     color: var(--sl-color-text-accent);
   }
 
-  .author[href]:hover {
-    color: var(--sl-color-white);
+  .title {
+    font-size: var(--sl-text-xs);
+    color: var(--sl-color-text);
+  }
+
+  .author:hover .name {
+    color: var(--sl-color-text);
   }
 
   img {

--- a/packages/starlight-blog/schema.ts
+++ b/packages/starlight-blog/schema.ts
@@ -7,6 +7,10 @@ export const blogAuthorSchema = z.object({
    */
   name: z.string().min(1),
   /**
+   * The title of the author.
+   */
+  title: z.string().optional(),
+  /**
    * The URL or path to the author's picture.
    */
   picture: z.string().optional(),

--- a/packages/starlight-blog/tests/post.test.ts
+++ b/packages/starlight-blog/tests/post.test.ts
@@ -32,6 +32,12 @@ test('should use the referenced authors specified in the frontmatter', async ({ 
   await expect(postPage.page.getByRole('link', { name: 'HiDeoo' })).toBeVisible()
 })
 
+test('should display author title', async ({ postPage }) => {
+  await postPage.goto('sequantur-quaeritis-tandem')
+
+  await expect(postPage.page.getByRole('link', { name: 'Starlight MVP' })).toBeVisible()
+})
+
 test('should not display tags in a post not having tags', async ({ postPage }) => {
   await postPage.goto('post-2')
 

--- a/packages/starlight-blog/tests/post.test.ts
+++ b/packages/starlight-blog/tests/post.test.ts
@@ -35,7 +35,7 @@ test('should use the referenced authors specified in the frontmatter', async ({ 
 test('should display author title', async ({ postPage }) => {
   await postPage.goto('sequantur-quaeritis-tandem')
 
-  await expect(postPage.page.getByRole('link', { name: 'Starlight MVP' })).toBeVisible()
+  await expect(postPage.page.getByRole('link', { name: 'Starlight Legend' })).toBeVisible()
 })
 
 test('should not display tags in a post not having tags', async ({ postPage }) => {

--- a/packages/starlight-blog/tests/post.test.ts
+++ b/packages/starlight-blog/tests/post.test.ts
@@ -35,11 +35,11 @@ test('should use the referenced authors specified in the frontmatter', async ({ 
 test('should display author title', async ({ postPage }) => {
   await postPage.goto('sequantur-quaeritis-tandem')
 
-  await expect(postPage.page.getByRole('link', { name: 'Starlight Legend' })).toBeVisible()
+  await expect(postPage.page.getByRole('link', { name: 'Starlight Aficionado' })).toBeVisible()
 })
 
 test('should not display tags in a post not having tags', async ({ postPage }) => {
-  await postPage.goto('post-2')
+  await postPage.goto('mihi-terrae-somnia')
 
   await expect(postPage.page.getByText('Tags: ', { exact: true })).not.toBeVisible()
 })


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

Adds an optional author title field.

<img width="176" alt="Screenshot 2023-08-27 at 15 14 25" src="https://github.com/HiDeoo/starlight-blog/assets/15347255/88b684b0-d539-4a98-8b32-48767eeb661d">
<img width="173" alt="Screenshot 2023-08-27 at 15 17 40" src="https://github.com/HiDeoo/starlight-blog/assets/15347255/ef0e1533-5e56-471c-9e2f-f728b42e9322">

**Why**

Additional feature parity with Docusaurus blogs: https://docusaurus.io/docs/blog#blog-post-authors

**How**

Added optional `title` field to the `author` schema and then add to the `Author.astro` component.