### PR TITLE
fix: text color of authors with no website

### DIFF
--- a/example/src/content/docs/blog/Ipsum-nunc-aliquet.md
+++ b/example/src/content/docs/blog/Ipsum-nunc-aliquet.md
@@ -1,0 +1,58 @@
+---
+title: Ipsum nunc aliquet
+date: 2020-10-10
+excerpt: Aenean id blandit quam, hendrerit molestie est. Proin faucibus eros nibh, tempus posuere neque consectetur non. Mauris vel nibh quis tellus aliquam semper id a sem. Praesent et varius massa. Suspendisse potenti. Vivamus commodo varius nisl, quis malesuada justo aliquam.
+authors:
+  - name: Ghost
+    picture: https://avatars.githubusercontent.com/u/10137?s=200
+tags:
+  - Starlight
+---
+
+## Nostris sollerti dedit
+
+Lorem markdownum hordea, tenaci iam Aeetias potuit, tardus et? Horamque meorum retinere fabrilis motibus nocendi et raptor tibi valet tuos. Sed Iove, superantque huic?
+
+1. Infelix forte Stygio et modo virtutem pendent
+2. Apertum et nostro nequiquam et avidus vidit
+3. Corpore in eodem audiat tantum Aethiopesque usus
+4. Inbutum simulacraque ardua faticinasque quod tecto tenere
+5. Fulmine celeberrima invida
+6. Certa nec
+
+## Magnum eodem nec
+
+Quas attollo vocat. Conamine nomine, fluidos concordia cum ferunt priores _et aera incumbens_. Quam quoque orbis advocat fide fert opaca cinctaque. Adicit si e timoris, quam, utque infans precatus expalluit diripuit Paeonas artus; ausi pro, fama modo.
+
+> Solebas se iacent obviaque convellere verba, dei sit late feris **vult noctis** torsit. Corpora aut et reccidit percusso: pro inponi formam vertice deficeret. Odium sed in tellus auxilium anxia. Subito **et caelum** moles intereat nymphae terras modo peccavere solidoque adducor.
+
+## Traharis miserae contraria quem cinerem tamen haberent
+
+Possit dedit illi induxerat aconiton, fuit. Spatium mandabat tractus medere virgineusque ergo traiecit vates. Non fida _perfundit cum_ oro vidi cum erubuit venit; ad illuc.
+
+Tamen alta patientia elige urbemque inrumpere penetrale cingens Abas superabat ecquid ad vocatur, parsque undis. Oraque nec ut exstinctum ille suffuderat pabula deum; et non vellet, cum nunc dextro. Hymenaeus damnum modo: non corna sit, vale altius, _novitate_. Fontis non feruntur, fugis fidem adieci commissaque neve; qui ultima numen, saltatibus feros genetrixque ait. Satus quoniam possunt Tmolus infamis cernis fluctus, se timent inque.
+
+## Soleo pereunt ferro sapienter perierunt filia nudumque
+
+Omnia adpulit imagine tempore vatis vivaque sonuit it contudit ungues. _Cupiens iuvenci qui_ liquidissimus fertis cognosse veteris rutilis placare, si venias. Dianae absens _tardata_ felicia sospes qua genuit, os nostra audet. Summae sollicitat positus. Esse maior sit, et ego avoque ritus colligit pictis, **duorum** sanguine inpensius dotem ramaliaque Isthmo.
+
+```
+if (accessMainframeGraymail.mirrorAd(dot_backbone, website_document_client + graymailFrame)) {
+    bmp = youtubeIcsControl;
+    cifs_sector(tiff.cdma_dvd(-3, 11));
+}
+if (crt + marginCircuit < key.olap(loginCopyOle.technologySignatureDomain(2, home), megapixel_solid.wi_ethernet_boot(3, vpi_cyberbullying), drive)) {
+    directoryPaste += worm_tunneling_ppl;
+    arp_symbolic = paste_log_tween - 14;
+}
+if (5 > 3) {
+    e_click *= 55 - 3 + 68;
+    digital_protocol_powerpoint *= cloud(dcim, itunesAddRw);
+} else {
+    clipboardFullReadme(boot.hashtag.webcamMount(default, mac_network, remote));
+    crop /= -1;
+}
+footerTcpWildcard(-2, intellectual + exploit(1, 5), configuration(handleZettabyte) + dashboard);
+```
+
+Haec multoque coniuge, sic crescere ne hanc in: aut portasse spes, egerere in. Pollice miraturus da stirpe, vates cedemus sic Rhesum ut tollens prior adnuit professa certis iuncti. E ratus dicere.

--- a/example/src/content/docs/blog/Ipsum-nunc-aliquet.md
+++ b/example/src/content/docs/blog/Ipsum-nunc-aliquet.md
@@ -5,8 +5,6 @@ excerpt: Aenean id blandit quam, hendrerit molestie est. Proin faucibus eros nib
 authors:
   - name: Ghost
     picture: https://avatars.githubusercontent.com/u/10137?s=200
-tags:
-  - Starlight
 ---
 
 ## Nostris sollerti dedit

--- a/packages/starlight-blog/components/Author.astro
+++ b/packages/starlight-blog/components/Author.astro
@@ -34,6 +34,9 @@ const Element = isLink ? 'a' : 'div'
   .name {
     font-size: var(--sl-text-base);
     font-weight: 600;
+  }
+
+  .author[href] .name {
     color: var(--sl-color-text-accent);
   }
 
@@ -42,7 +45,7 @@ const Element = isLink ? 'a' : 'div'
     color: var(--sl-color-text);
   }
 
-  .author:hover .name {
+  .author[href]:hover .name {
     color: var(--sl-color-text);
   }
 


### PR DESCRIPTION
A light regression snuck into #2 where I removed the `[href]` check in the CSS. 

- Fixes CSS regression where an author would appear to be linked when no URL was specified
- Adds a new blog post to be able to visually test this behaviour

Before (with no url):
<img width="121" alt="Screenshot 2023-08-28 at 13 30 02" src="https://github.com/HiDeoo/starlight-blog/assets/15347255/67ae3d0d-8bbe-412c-9928-57eb3d420d83">

After (with no url):
<img width="132" alt="Screenshot 2023-08-28 at 13 30 35" src="https://github.com/HiDeoo/starlight-blog/assets/15347255/dd075723-e604-4a8a-8128-bc8cd65f7a0f">
