### PR TITLE
Uses Astro’s built-in optimized asset support for author profile images

### DIFF
--- a/packages/starlight-blog/components/Author.astro
+++ b/packages/starlight-blog/components/Author.astro
@@ -1,4 +1,6 @@
 ---
+import { Image } from 'astro:assets'
+
 import { getPathWithBase } from '../libs/page'
 import type { StarlightBlogAuthor } from '../schema'
 
@@ -19,7 +21,7 @@ const pictureSrc = author.picture
 ---
 
 <Element href={isLink ? author.url : undefined} class="author">
-  {pictureSrc && <img alt={author.name} src={pictureSrc} />}
+  {pictureSrc && <Image alt={author.name} loading="eager" src={pictureSrc} height={40} width={40} />}
   <div class="text">
     <div class="name">{author.name}</div>
     {author.title && <div class="title">{author.title}</div>}


### PR DESCRIPTION
Closes #52 

Note that on some pages (blog posts and tags listing), another error ([`perf-use-loading-lazy`](https://github.com/withastro/astro/blob/233fee9c04ba5d9cbcda13a93f9f6d8ecd5794d8/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/perf.ts#L29-L46)) may appear based on the number/length of posts, height of the page, etc. and we cannot control that reliably.