### PR TITLE
docs: use 200x200 GitHub avatars in Authors guide examples

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -53,5 +53,8 @@ export default defineConfig({
       title: 'Starlight Blog',
     }),
   ],
+  image: {
+    domains: ['avatars.githubusercontent.com'],
+  },
   site: 'https://starlight-blog-docs.vercel.app',
 })

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -122,3 +122,4 @@ A URL to link the author's name to.
 **Type:** `string`
 
 A URL or path to an image in the `public/` directory to display as the author's picture.
+When using remote images, check out the [“Authorizing remote images”](https://docs.astro.build/en/guides/images/#authorizing-remote-images) guide to enable image optimization.

--- a/docs/src/content/docs/guides/authors.md
+++ b/docs/src/content/docs/guides/authors.md
@@ -13,7 +13,7 @@ Authors can be defined in a blog post using the `authors` frontmatter property a
 authors:
   name: HiDeoo
   title: Starlight Aficionado
-  picture: https://avatars.githubusercontent.com/u/494699
+  picture: https://avatars.githubusercontent.com/u/494699?s=200
   url: https://hideoo.dev
 ---
 ```
@@ -26,10 +26,10 @@ Multiple authors can be defined using an array:
 authors:
   - name: HiDeoo
     title: Starlight Aficionado
-    picture: https://avatars.githubusercontent.com/u/494699
+    picture: https://avatars.githubusercontent.com/u/494699?s=200
     url: https://hideoo.dev
   - name: Ghost
-    picture: https://avatars.githubusercontent.com/u/10137
+    picture: https://avatars.githubusercontent.com/u/10137?s=200
     url: https://github.com/ghost
 ---
 ```
@@ -62,7 +62,7 @@ A blog post frontmatter can also reference a global author using the key of the 
 authors:
   - hideoo # Will use the author defined in the configuration with the `hideoo` key.
   - name: Ghost
-    picture: https://avatars.githubusercontent.com/u/10137
+    picture: https://avatars.githubusercontent.com/u/10137?s=200
     url: https://github.com/ghost
 ---
 ```


### PR DESCRIPTION
_Note: I did not bother creating an issue for this, considering the simplicity of the change._

**Describe the pull request**

This PR suggests updating the [Guide > Authors](https://starlight-blog-docs.vercel.app/guides/authors/) examples to specify the size of the GitHub avatars to 200x200, as it is the case for the live examples at [demo blog](https://starlight-blog-docs.vercel.app/blog).

**Context**

By default, a GitHub avatar image can be pretty big; https://avatars.githubusercontent.com/u/10137 is for example a 460x460 image that weighs around 300kB.
For the ghost image (https://avatars.githubusercontent.com/u/10137), it's lower and only 16kB.
So it will depend on the image.

In the [demo blog](https://starlight-blog-docs.vercel.app/blog), we can see that these images are rendered next to the authors' information in small.

| URL  | Size and weight | Rendering  | Zoomed rendering  |
|---|---|---|---|
| https://avatars.githubusercontent.com/u/10137  | 460x460 (16.41kB)  | ![Screenshot 2024-06-30 at 20 31 40](https://github.com/HiDeoo/starlight-blog/assets/17381666/02b75b01-3c75-43c1-923e-086e83b394e8)  | ![Screenshot 2024-06-30 at 20 32 25](https://github.com/HiDeoo/starlight-blog/assets/17381666/3bed6302-d2f6-454f-bce2-c7d8917ecaae)  | 
| https://avatars.githubusercontent.com/u/10137?s=200 | 200x200 (4.25kB) | ![Screenshot 2024-06-30 at 20 35 26](https://github.com/HiDeoo/starlight-blog/assets/17381666/69d9cf2e-508e-4c93-9c39-d23cb5d7eec8) | ![Screenshot 2024-06-30 at 20 33 03](https://github.com/HiDeoo/starlight-blog/assets/17381666/8e57cfa1-6793-4e89-9000-812c5b739a1c) |
| https://avatars.githubusercontent.com/u/10137?s=96 | 96x96 (1.84kB) | ![Screenshot 2024-06-30 at 20 35 01](https://github.com/HiDeoo/starlight-blog/assets/17381666/85c5469e-2d35-4897-9677-6449ffc5864e) | ![Screenshot 2024-06-30 at 20 33 35](https://github.com/HiDeoo/starlight-blog/assets/17381666/f3339672-e7eb-4970-b1a6-8ff128bde07e) |
| https://avatars.githubusercontent.com/u/10137?s=48 | 48x48 (1.07kB) | ![Screenshot 2024-06-30 at 20 34 38](https://github.com/HiDeoo/starlight-blog/assets/17381666/29af6a4a-4ad8-4227-bf33-2c41565394b7) | ![Screenshot 2024-06-30 at 20 34 09](https://github.com/HiDeoo/starlight-blog/assets/17381666/e0354c07-2b6b-47fd-a09e-f4de65e334d4) |

When not zoomed, TBH, the rendering is almost the same. When zoomed, at 48x48, it's pretty blurry, and we can feel the difference between 96x96 and 200x200. And between 200x200 and 460x460 (default), you must zoom even more to see the difference, IMHO.

Based on these elements, your choice in the different examples seems to be pretty good one as it already saves some kBs.

**Why**

So the examples in [demo blog](https://starlight-blog-docs.vercel.app/blog) use a good size, but this good practice is not reflected into the documentation at [Guide > Authors](https://starlight-blog-docs.vercel.app/guides/authors/) where no size is set when using GitHub avatars.

**However**, this is maybe on purpose in order to avoid adding complexity to the main point of this page, which is to configure the authors.

**I let you decide if it is worth a change or not, feel free to close this PR directly if this change is not a good idea or for any other reasons :)**


