### PR TITLE
feat: adds support for specifying a blog post's updated date

### DIFF
--- a/docs/src/content/docs/blog/sequantur-quaeritis-tandem.md
+++ b/docs/src/content/docs/blog/sequantur-quaeritis-tandem.md
@@ -1,6 +1,7 @@
 ---
 title: Sequantur quaeritis tandem
 date: 2021-01-13
+updateDate: 2021-01-13
 excerpt: Donec eget **vestibulum** leo. Curabitur vel pretium nulla, in bibendum neque. In molestie lorem massa, eu bibendum eros gravida nec. Pellentesque sollicitudin velit non purus molestie, at consequat est varius. Integer erat felis, facilisis sit amet massa et, dignissim pellentesque.
 tags:
   - Starlight

--- a/docs/src/content/docs/blog/vario-nunc-polo.md
+++ b/docs/src/content/docs/blog/vario-nunc-polo.md
@@ -1,6 +1,7 @@
 ---
 title: Vario nunc polo
 date: 2020-12-12
+updateDate: 2021-12-30
 tags:
   - Placeholder
 authors:

--- a/docs/src/content/docs/guides/frontmatter.md
+++ b/docs/src/content/docs/guides/frontmatter.md
@@ -42,6 +42,18 @@ date: 2024-03-11
 ---
 ```
 
+### `updateDate`
+
+**Type:** `Date`
+
+The last update date of the blog post which must be a valid [YAML timestamp](https://yaml.org/type/timestamp.html). Displayed only if different from the `date`.
+
+```md
+---
+updateDate: 2024-07-01
+---
+```
+
 ### `tags`
 
 **Type:** `string[]`

--- a/docs/src/content/docs/guides/frontmatter.md
+++ b/docs/src/content/docs/guides/frontmatter.md
@@ -46,7 +46,8 @@ date: 2024-03-11
 
 **Type:** `Date`
 
-The last update date of the blog post which must be a valid [YAML timestamp](https://yaml.org/type/timestamp.html). Displayed only if different from the `date`.
+The last update date of the blog post which must be a valid [YAML timestamp](https://yaml.org/type/timestamp.html).
+Displayed only if different from the [`date`](#date-required).
 
 ```md
 ---

--- a/packages/starlight-blog/components/Metadata.astro
+++ b/packages/starlight-blog/components/Metadata.astro
@@ -14,13 +14,24 @@ const { entry, showBadges = true } = Astro.props
 const { authors, date, updateDate } = getBlogEntryMetadata(entry)
 
 const hasAuthors = authors.length > 0
-const hasUpdateDate = updateDate !== undefined
+const showUpdateDate =
+  updateDate !== undefined && entry.data.updateDate?.toISOString() !== entry.data.date.toISOString()
 ---
 
 <div class="metadata not-content">
-  <time datetime={entry.data.date.toISOString()}>
-    {date}
-  </time>
+  <div class="dates">
+    <time datetime={entry.data.date.toISOString()}>
+      {date}
+    </time>
+    {
+      showUpdateDate ? (
+        <span class="update-date">
+          - Last update:
+          <time datetime={entry.data.updateDate?.toISOString()}>{updateDate}</time>
+        </span>
+      ) : null
+    }
+  </div>
   {
     hasAuthors ? (
       <div class="authors">
@@ -28,13 +39,6 @@ const hasUpdateDate = updateDate !== undefined
           <Author {author} />
         ))}
       </div>
-    ) : null
-  }
-  {
-    hasUpdateDate && entry.data.updateDate?.toISOString() !== entry.data.date.toISOString() ? (
-      <time class="update-date" datetime={entry.data.updateDate?.toISOString()}>
-        Last update: {updateDate}
-      </time>
     ) : null
   }
   {
@@ -53,12 +57,12 @@ const hasUpdateDate = updateDate !== undefined
     gap: 0.75rem;
   }
 
-  time {
+  .dates {
     font-size: var(--sl-text-sm);
   }
 
-  time.update-date {
-    font-size: var(--sl-text-xs);
+  .update-date {
+    color: var(--sl-color-gray-3);
   }
 
   .authors {

--- a/packages/starlight-blog/components/Metadata.astro
+++ b/packages/starlight-blog/components/Metadata.astro
@@ -11,9 +11,10 @@ interface Props {
 }
 
 const { entry, showBadges = true } = Astro.props
-const { authors, date } = getBlogEntryMetadata(entry)
+const { authors, date, updateDate } = getBlogEntryMetadata(entry)
 
 const hasAuthors = authors.length > 0
+const hasUpdateDate = updateDate !== undefined
 ---
 
 <div class="metadata not-content">
@@ -27,6 +28,13 @@ const hasAuthors = authors.length > 0
           <Author {author} />
         ))}
       </div>
+    ) : null
+  }
+  {
+    hasUpdateDate && entry.data.updateDate?.toISOString() !== entry.data.date.toISOString() ? (
+      <time class="update-date" datetime={entry.data.updateDate?.toISOString()}>
+        Last update: {updateDate}
+      </time>
     ) : null
   }
   {
@@ -47,6 +55,10 @@ const hasAuthors = authors.length > 0
 
   time {
     font-size: var(--sl-text-sm);
+  }
+
+  time.update-date {
+    font-size: var(--sl-text-xs);
   }
 
   .authors {

--- a/packages/starlight-blog/libs/content.ts
+++ b/packages/starlight-blog/libs/content.ts
@@ -102,6 +102,7 @@ export function getBlogEntryMetadata(entry: StarlightBlogEntry): StarlightBlogEn
   return {
     authors,
     date: entry.data.date.toLocaleDateString(starlightConfig.defaultLocale.lang, { dateStyle: 'medium' }),
+    updateDate: entry.data.updateDate?.toLocaleDateString(starlightConfig.defaultLocale.lang, { dateStyle: 'medium' }),
   }
 }
 
@@ -178,6 +179,7 @@ export interface StarlightBlogEntryPaginated {
 interface StarlightBlogEntryMetadata {
   authors: StarlightBlogAuthor[]
   date: string
+  updateDate: string | undefined
 }
 
 interface StarlightBlogStaticProps {

--- a/packages/starlight-blog/schema.ts
+++ b/packages/starlight-blog/schema.ts
@@ -34,6 +34,7 @@ export const blogEntrySchema = ({ image }: SchemaContext) =>
     date: z.date(),
     /**
      * The last update date of the blog post which must be a valid YAML timestamp.
+     * @see https://yaml.org/type/timestamp.html
      */
     updateDate: z.date().optional(),
     /**

--- a/packages/starlight-blog/schema.ts
+++ b/packages/starlight-blog/schema.ts
@@ -33,6 +33,10 @@ export const blogEntrySchema = ({ image }: SchemaContext) =>
      */
     date: z.date(),
     /**
+     * The last update date of the blog post which must be a valid YAML timestamp.
+     */
+    updateDate: z.date().optional(),
+    /**
      * The excerpt of the blog post used in the blog post list and tags pages.
      * If not provided, the entire blog post content will be rendered.
      */

--- a/packages/starlight-blog/tests/e2e/blog.test.ts
+++ b/packages/starlight-blog/tests/e2e/blog.test.ts
@@ -148,7 +148,7 @@ test('should display a preview of each posts', async ({ blogPage }) => {
 test('should use sorted posts', async ({ blogPage }) => {
   await blogPage.goto()
 
-  const times = await blogPage.page.getByRole('article').locator('time').all()
+  const times = await blogPage.page.getByRole('article').locator(':not(.update-date) > time').all()
   const datetimes = await Promise.all(times.map((time) => time.getAttribute('datetime')))
 
   const dates = datetimes.map((datetime) => {


### PR DESCRIPTION
**Describe the pull request**

This PR adds an optional new `updateDate` field for blog posts to define the last update that happened.

**Why**

This information can be interesting for readers when blog posts have been updated after feedback from the readers, typos, changes of URL, or adaptation for whatever reason.

**How**

* The schema at `packages/starlight-blog/schema.ts` has been updated to add a new `updateDate` field which is an optional date
* It is considered as a metadata information so `packages/starlight-blog/libs/content.ts` has been modified to include this new field
* In terms of rendering, this `updateDate` value has been treated like the `date` value and is handled in `packages/starlight-blog/components/Metadata.astro`:
  * Being secondary information, I chose arbitrarily to display it with a small size via `var(--sl-text-xs);`
  * Initially, I tried to display it under the publication date, but the rendering was weird. Putting it after the authors seem more elegant, even if maybe we lose the logical link between the 2 dates
  * Please note that this `updateDate` is not rendered if it's not defined, or that its content has the same value as the publication `date`
* Testing:
    * "visual tests" has been added in `docs/src/content/docs/blog/vario-nunc-polo.md` and `docs/src/content/docs/blog/sequantur-quaeritis-tandem.md`
    * I wasn't sure if it was necessary to add e2e tests that didn't seem appropriate for that. Please tell me if some must be added
* RSS: IMHO there's no impact on the RSS part since there's no update date defined in https://www.w3schools.com/xml/xml_rss.asp#rssref. It only exists as `lastBuildDate` for the channels. Plus, I don't think we need to modify the `pubDate` to use the `updateDate` as it would modify the order of appearance of the blog posts, even if it is mentioned that `pubDate` is supposed to be the "last-publication" date for the item. I'm not 100% sure about it, but I would handle it like this.

**Some links**

* Updated documentation: https://starlight-blog-docs-git-fork-julien-der-df4974-hideoos-projects.vercel.app/guides/frontmatter/
* Demo blog: https://starlight-blog-docs-git-fork-julien-der-df4974-hideoos-projects.vercel.app/blog
  * "Sequantur quaeritis tandem" has the same `updateDate` as the `date`, so the `updateDate` is not rendered
  * "Vario nunc polo" has a different `updateDate`, so it is rendered
  * The other blog posts don't have any `updateDate`, so it's not rendered

**Screenshots**

![Screenshot 2024-07-01 at 11 29 53](https://github.com/HiDeoo/starlight-blog/assets/17381666/d76cd68c-50cb-4f95-bbc1-d0d8a17afe8a)

