### PR TITLE
Change Separation Character

### DIFF
--- a/packages/starlight-blog/components/Metadata.astro
+++ b/packages/starlight-blog/components/Metadata.astro
@@ -26,7 +26,7 @@ const hasAuthors = authors.length > 0
       typeof entry.data.lastUpdated !== 'boolean' &&
       entry.data.lastUpdated?.toISOString() !== entry.data.date.toISOString() ? (
         <span class="update-date">
-          - Last update:
+          <span style="margin-inline: 0.25rem;">•</span> Last update:
           <time datetime={entry.data.lastUpdated?.toISOString()}>{lastUpdated}</time>
         </span>
       ) : null


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

If @HiDeoo wants to adapt the separation character from `-` to `•` like I mentioned in [#72](https://github.com/HiDeoo/starlight-blog/issues/72#issuecomment-2254115246) I changed the code necessarily...

**Why**

See the discussion above.

**How**

Only changes made in `Metadata.astro`.

**Screenshots**

![image](https://github.com/user-attachments/assets/b3e2af90-0fd2-4e5e-a680-d97aa501c436)
