### PR TITLE
RSS Feed Filter Import Statements

### DIFF
--- a/packages/starlight-blog/libs/markdown.ts
+++ b/packages/starlight-blog/libs/markdown.ts
@@ -7,6 +7,8 @@ import swap from 'ultrahtml/transformers/swap'
 const markedMd = new Marked({ gfm: true })
 const markedText = new Marked({ gfm: true }, markedPlaintify())
 
+const importRegex = /^import\s.+?from\s.+?;?$/gm
+
 const imagePlaceholder =
   'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MDAgMjUwIiB3aWR0aD0iNDAwIiBoZWlnaHQ9IjI1MCI+CiAgPHJlY3Qgd2lkdGg9IjQwMCIgaGVpZ2h0PSIyNTAiIGZpbGw9IiNCM0IwQjBGRiI+PC9yZWN0PgogIDx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjI1cHgiIGZpbGw9IiMyNjI2MjZGRiI+SW1hZ2U8L3RleHQ+ICAgCjwvc3ZnPg=='
 
@@ -15,7 +17,8 @@ export async function stripMarkdown(markdown: string) {
 }
 
 export async function renderMarkdownToHTML(markdown: string, link: URL, imageFallbackLabel: string) {
-  const content = await markedMd.parse(markdown)
+  const sanitizedMarkdown = markdown.replaceAll(importRegex, '')
+  const content = await markedMd.parse(sanitizedMarkdown)
 
   return transform(content, [
     swap({


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

- adjust `markdown.ts` lib file to filter import statements with a regex pattern

**Why**

Import statements should not be included in an RSS feed because we just want content.
This PR fixes #92 

**How**

- adjustments in the `markdown.ts` file
