### PR TITLE
Ensure trailing slashes with `trailingSlash: 'ignore'`

### DIFF
--- a/.changeset/spotty-news-act.md
+++ b/.changeset/spotty-news-act.md
@@ -1,0 +1,5 @@
+---
+'starlight-blog': minor
+---
+
+Respects Starlight convention to generate URLs with a trailing slash when using the [`trailingSlash: 'ignore'`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) Astro configuration option (the default) as many common hosting providers redirect to URLs with a trailing slash by default.

--- a/packages/starlight-blog/libs/page.ts
+++ b/packages/starlight-blog/libs/page.ts
@@ -11,7 +11,7 @@ import { ensureTrailingSlash, stripLeadingSlash, stripTrailingSlash } from './pa
 
 const trailingSlashTransformers: Record<AstroConfig['trailingSlash'], (path: string) => string> = {
   always: ensureTrailingSlash,
-  ignore: (href) => href,
+  ignore: ensureTrailingSlash,
   never: stripTrailingSlash,
 }
 

--- a/packages/starlight-blog/tests/e2e/blog.test.ts
+++ b/packages/starlight-blog/tests/e2e/blog.test.ts
@@ -6,7 +6,7 @@ test('should add a blog link to the header of all pages with the configured titl
   const link = blogPage.page.getByRole('link', { exact: true, name: 'Demo Blog' })
 
   await expect(link).toBeVisible()
-  await expect(link).toHaveAttribute('href', '/blog')
+  await expect(link).toHaveAttribute('href', '/blog/')
 })
 
 test('should use the configured title for the page', async ({ blogPage }) => {
@@ -70,7 +70,7 @@ test('should add a link to all posts in the sidebar', async ({ blogPage }) => {
   const link = blogPage.sidebar.getByRole('link', { name: 'All posts' })
 
   await expect(link).toBeVisible()
-  await expect(link).toHaveAttribute('href', '/blog')
+  await expect(link).toHaveAttribute('href', '/blog/')
 })
 
 test('should add links to recent posts in the sidebar', async ({ blogPage }) => {
@@ -300,7 +300,7 @@ test.describe('i18n', () => {
 
     await expect(blogPage.page.getByRole('link', { exact: true, name: 'Blog Démo' })).toHaveAttribute(
       'href',
-      '/fr/blog',
+      '/fr/blog/',
     )
   })
 
@@ -333,7 +333,7 @@ test.describe('i18n', () => {
   test('should add a localized link to all posts in the sidebar', async ({ blogPage }) => {
     await blogPage.goto(undefined, 'fr')
 
-    await expect(blogPage.sidebar.getByRole('link', { name: 'Tous les articles' })).toHaveAttribute('href', '/fr/blog')
+    await expect(blogPage.sidebar.getByRole('link', { name: 'Tous les articles' })).toHaveAttribute('href', '/fr/blog/')
   })
 
   test('should add localized links to recent posts in the sidebar', async ({ blogPage }) => {
@@ -394,7 +394,7 @@ test.describe('i18n', () => {
     const frPostLink = titles.getByRole('link', { name: 'Achivi amans (fr)' })
 
     await expect(frPostLink).toBeVisible()
-    await expect(frPostLink).toHaveAttribute('href', '/fr/blog/achivi-amans')
+    await expect(frPostLink).toHaveAttribute('href', '/fr/blog/achivi-amans/')
 
     await expect(articles.getByText('12 déc. 2020')).toBeVisible()
     await expect(articles.getByText('30 déc. 2021')).toBeVisible()
@@ -403,7 +403,7 @@ test.describe('i18n', () => {
 
     const frTag = articles.getByRole('link', { name: 'Ébauche' })
     await expect(frTag).toBeVisible()
-    await expect(frTag).toHaveAttribute('href', '/fr/blog/tags/ébauche')
+    await expect(frTag).toHaveAttribute('href', '/fr/blog/tags/ébauche/')
 
     const links = await titles.getByRole('link').all()
     const hrefs = await Promise.all(links.map((link) => link.getAttribute('href')))

--- a/packages/starlight-blog/tests/e2e/post.test.ts
+++ b/packages/starlight-blog/tests/e2e/post.test.ts
@@ -53,38 +53,38 @@ test('should display tags in a post having tags', async ({ postPage }) => {
   const amazingContentTag = postPage.content.getByRole('link', { exact: true, name: 'Amazing Content' })
 
   await expect(starlightTag).toBeVisible()
-  await expect(starlightTag).toHaveAttribute('href', '/blog/tags/starlight')
+  await expect(starlightTag).toHaveAttribute('href', '/blog/tags/starlight/')
 
   await expect(amazingContentTag).toBeVisible()
-  await expect(amazingContentTag).toHaveAttribute('href', '/blog/tags/amazing-content')
+  await expect(amazingContentTag).toHaveAttribute('href', '/blog/tags/amazing-content/')
 })
 
 test('should display navigation links', async ({ postPage }) => {
   await postPage.goto('nitidum-fuit')
 
   await expect(postPage.prevLink).toBeVisible()
-  await expect(postPage.prevLink).toHaveAttribute('href', '/blog/funda-pro')
+  await expect(postPage.prevLink).toHaveAttribute('href', '/blog/funda-pro/')
   await expect(postPage.nextLink).not.toBeVisible()
 
   await postPage.goto('funda-pro')
 
   await expect(postPage.prevLink).toBeVisible()
-  await expect(postPage.prevLink).toHaveAttribute('href', '/blog/spectat-fingit')
+  await expect(postPage.prevLink).toHaveAttribute('href', '/blog/spectat-fingit/')
   await expect(postPage.nextLink).toBeVisible()
-  await expect(postPage.nextLink).toHaveAttribute('href', '/blog/nitidum-fuit')
+  await expect(postPage.nextLink).toHaveAttribute('href', '/blog/nitidum-fuit/')
 
   await postPage.goto('vario-nunc-polo')
 
   await expect(postPage.prevLink).toBeVisible()
-  await expect(postPage.prevLink).toHaveAttribute('href', '/blog/sequantur-quaeritis-tandem')
+  await expect(postPage.prevLink).toHaveAttribute('href', '/blog/sequantur-quaeritis-tandem/')
   await expect(postPage.nextLink).toBeVisible()
-  await expect(postPage.nextLink).toHaveAttribute('href', '/blog/mihi-terrae-somnia')
+  await expect(postPage.nextLink).toHaveAttribute('href', '/blog/mihi-terrae-somnia/')
 
   await postPage.goto('sequantur-quaeritis-tandem')
 
   await expect(postPage.prevLink).not.toBeVisible()
   await expect(postPage.nextLink).toBeVisible()
-  await expect(postPage.nextLink).toHaveAttribute('href', '/blog/vario-nunc-polo')
+  await expect(postPage.nextLink).toHaveAttribute('href', '/blog/vario-nunc-polo/')
 })
 
 test('should include a cover image', async ({ postPage }) => {
@@ -114,31 +114,31 @@ test.describe('i18n', () => {
     const tag = postPage.content.getByRole('link', { exact: true, name: 'Ébauche' })
 
     await expect(tag).toBeVisible()
-    await expect(tag).toHaveAttribute('href', '/fr/blog/tags/ébauche')
+    await expect(tag).toHaveAttribute('href', '/fr/blog/tags/ébauche/')
   })
 
   test('should display localized navigation links', async ({ postPage }) => {
     await postPage.goto('nitidum-fuit', 'fr')
 
-    await expect(postPage.prevLink).toHaveAttribute('href', '/fr/blog/funda-pro')
+    await expect(postPage.prevLink).toHaveAttribute('href', '/fr/blog/funda-pro/')
 
     await postPage.goto('funda-pro', 'fr')
 
-    await expect(postPage.prevLink).toHaveAttribute('href', '/fr/blog/spectat-fingit')
-    await expect(postPage.nextLink).toHaveAttribute('href', '/fr/blog/nitidum-fuit')
+    await expect(postPage.prevLink).toHaveAttribute('href', '/fr/blog/spectat-fingit/')
+    await expect(postPage.nextLink).toHaveAttribute('href', '/fr/blog/nitidum-fuit/')
 
     await postPage.goto('vario-nunc-polo', 'fr')
 
-    await expect(postPage.prevLink).toHaveAttribute('href', '/fr/blog/sequantur-quaeritis-tandem')
-    await expect(postPage.nextLink).toHaveAttribute('href', '/fr/blog/mihi-terrae-somnia')
+    await expect(postPage.prevLink).toHaveAttribute('href', '/fr/blog/sequantur-quaeritis-tandem/')
+    await expect(postPage.nextLink).toHaveAttribute('href', '/fr/blog/mihi-terrae-somnia/')
 
     await postPage.goto('sequantur-quaeritis-tandem', 'fr')
 
     await expect(postPage.prevLink).not.toBeVisible()
-    await expect(postPage.nextLink).toHaveAttribute('href', '/fr/blog/vario-nunc-polo')
+    await expect(postPage.nextLink).toHaveAttribute('href', '/fr/blog/vario-nunc-polo/')
 
     await postPage.goto('ipsum-nunc-aliquet', 'fr')
-    await expect(postPage.nextLink).toHaveAttribute('href', '/fr/blog/achivi-amans')
+    await expect(postPage.nextLink).toHaveAttribute('href', '/fr/blog/achivi-amans/')
     await expect(postPage.nextLink).toHaveText('Achivi amans (fr)')
   })
 

--- a/packages/starlight-blog/tests/unit/basics/blog-data.test.ts
+++ b/packages/starlight-blog/tests/unit/basics/blog-data.test.ts
@@ -49,7 +49,7 @@ describe('posts', () => {
 
     expect(post.title).toBe('Post 7')
 
-    expect(post.href).toBe('/en/blog/post-7')
+    expect(post.href).toBe('/en/blog/post-7/')
 
     expect(post.createdAt).toBeInstanceOf(Date)
     expect(post.createdAt.toISOString()).toBe('2024-02-24T00:00:00.000Z')
@@ -59,8 +59,8 @@ describe('posts', () => {
     expect(post.authors).toEqual([{ name: 'HiDeoo' }])
 
     expect(post.tags).toEqual([
-      { label: 'tag-1', href: '/en/blog/tags/tag-1' },
-      { label: 'tag-2', href: '/en/blog/tags/tag-2' },
+      { label: 'tag-1', href: '/en/blog/tags/tag-1/' },
+      { label: 'tag-2', href: '/en/blog/tags/tag-2/' },
     ])
   })
 })

--- a/packages/starlight-blog/tests/unit/basics/page.test.ts
+++ b/packages/starlight-blog/tests/unit/basics/page.test.ts
@@ -4,13 +4,13 @@ import { getRelativeBlogUrl, getRelativeUrl } from '../../../libs/page'
 
 describe('getRelativeBlogUrl', () => {
   test('returns the blog root path', () => {
-    expect(getRelativeBlogUrl('/', undefined)).toBe('/blog')
-    expect(getRelativeBlogUrl('/', 'fr')).toBe('/fr/blog')
+    expect(getRelativeBlogUrl('/', undefined)).toBe('/blog/')
+    expect(getRelativeBlogUrl('/', 'fr')).toBe('/fr/blog/')
   })
 
   test('returns a blog post path', () => {
-    expect(getRelativeBlogUrl('/post-1', undefined)).toBe('/blog/post-1')
-    expect(getRelativeBlogUrl('/post-1', 'fr')).toBe('/fr/blog/post-1')
+    expect(getRelativeBlogUrl('/post-1', undefined)).toBe('/blog/post-1/')
+    expect(getRelativeBlogUrl('/post-1', 'fr')).toBe('/fr/blog/post-1/')
   })
 
   test('returns the RSS feed path', () => {
@@ -22,11 +22,11 @@ describe('getRelativeBlogUrl', () => {
 describe('getRelativeUrl', () => {
   describe('with no base', () => {
     test('returns the path with no base', () => {
-      expect(getRelativeUrl('/blog')).toBe('/blog')
+      expect(getRelativeUrl('/blog')).toBe('/blog/')
     })
 
     test('prefixes the path with a leading slash if needed', () => {
-      expect(getRelativeUrl('blog')).toBe('/blog')
+      expect(getRelativeUrl('blog')).toBe('/blog/')
     })
   })
 
@@ -42,7 +42,7 @@ describe('getRelativeUrl', () => {
 
     test('returns the path prefixed with the base', async () => {
       const { getRelativeUrl } = await import('../../../libs/page')
-      expect(getRelativeUrl('/blog')).toBe('/base/blog')
+      expect(getRelativeUrl('/blog')).toBe('/base/blog/')
     })
   })
 
@@ -51,8 +51,8 @@ describe('getRelativeUrl', () => {
       expect(getRelativeUrl('/blog/')).toBe('/blog/')
     })
 
-    test('does not ensure trailing slashes', () => {
-      expect(getRelativeUrl('/blog')).toBe('/blog')
+    test('ensures trailing slashes', () => {
+      expect(getRelativeUrl('/blog')).toBe('/blog/')
     })
   })
 })

--- a/packages/starlight-blog/tests/unit/basics/prev-next.test.ts
+++ b/packages/starlight-blog/tests/unit/basics/prev-next.test.ts
@@ -30,9 +30,9 @@ describe('getBlogStaticPaths', () => {
 
 describe('getBlogEntry', () => {
   test('respects the `prevNextLinksOrder` option in `reverse-chronological` order', async () => {
-    const post = await getBlogEntry('/blog/post-6', undefined)
+    const post = await getBlogEntry('/blog/post-6/', undefined)
 
-    expect(post.prevLink?.href).toBe('/blog/post-7')
-    expect(post.nextLink?.href).toBe('/blog/post-5')
+    expect(post.prevLink?.href).toBe('/blog/post-7/')
+    expect(post.nextLink?.href).toBe('/blog/post-5/')
   })
 })

--- a/packages/starlight-blog/tests/unit/prefix/page.test.ts
+++ b/packages/starlight-blog/tests/unit/prefix/page.test.ts
@@ -4,13 +4,13 @@ import { getRelativeBlogUrl } from '../../../libs/page'
 
 describe('getRelativeBlogUrl', () => {
   test('returns the blog root path', () => {
-    expect(getRelativeBlogUrl('/', undefined)).toBe('/news')
-    expect(getRelativeBlogUrl('/', 'fr')).toBe('/fr/news')
+    expect(getRelativeBlogUrl('/', undefined)).toBe('/news/')
+    expect(getRelativeBlogUrl('/', 'fr')).toBe('/fr/news/')
   })
 
   test('returns a blog post path', () => {
-    expect(getRelativeBlogUrl('/post-1', undefined)).toBe('/news/post-1')
-    expect(getRelativeBlogUrl('/post-1', 'fr')).toBe('/fr/news/post-1')
+    expect(getRelativeBlogUrl('/post-1', undefined)).toBe('/news/post-1/')
+    expect(getRelativeBlogUrl('/post-1', 'fr')).toBe('/fr/news/post-1/')
   })
 
   test('returns the RSS feed path', () => {

--- a/packages/starlight-blog/tests/unit/prev-next-chronological/prev-next.test.ts
+++ b/packages/starlight-blog/tests/unit/prev-next-chronological/prev-next.test.ts
@@ -30,9 +30,9 @@ describe('getBlogStaticPaths', () => {
 
 describe('getBlogEntry', () => {
   test('respects the `prevNextLinksOrder` option in `chronological` order', async () => {
-    const post = await getBlogEntry('/blog/post-6', undefined)
+    const post = await getBlogEntry('/blog/post-6/', undefined)
 
-    expect(post.prevLink?.href).toBe('/blog/post-5')
-    expect(post.nextLink?.href).toBe('/blog/post-7')
+    expect(post.prevLink?.href).toBe('/blog/post-5/')
+    expect(post.nextLink?.href).toBe('/blog/post-7/')
   })
 })


### PR DESCRIPTION
Closes #117 