### PR TITLE
set the order when middleware runs to "post"

### DIFF
--- a/packages/starlight-blog/index.ts
+++ b/packages/starlight-blog/index.ts
@@ -27,7 +27,7 @@ export default function starlightBlogPlugin(userConfig?: StarlightBlogUserConfig
         logger,
         updateConfig: updateStarlightConfig,
       }) {
-        addRouteMiddleware({ entrypoint: 'starlight-blog/middleware' })
+        addRouteMiddleware({ entrypoint: 'starlight-blog/middleware', order: 'post' })
 
         const rssLink = astroConfig.site
           ? `${stripTrailingSlash(astroConfig.site)}${stripTrailingSlash(astroConfig.base)}/${stripLeadingSlash(


### PR DESCRIPTION
**Describe the pull request**

Configure the starlight-blog middleware to run after other middlewares, thereby achieving compatibility with the Multi-Sidebar feature in the starlight-utils plugin. The benefit of this approach is that it allows simultaneous use of both starlight-blog and Multi-Sidebar: using the blog-specific sidebar on blog pages while utilizing Multi-Sidebar on other pages.

**Why**

Support writers use starlight-blog and Multi-Sidebar at the same time.

**How**

Just by set the order for `addRouteMiddlewareSection ` in the plugin, then put `starlight-blog` plugin after `starlight-utils`, at last, rewrite the starlight sidebar.This can be implemented with the following code:

``` js
// astro.config.mjs
import starlightUtils from "@lorenzo_lewis/starlight-utils";
import starlightBlog from 'starlight-blog'

export const BLOG_PREFIX = "blogs";

export default defineConfig({
  ...
  integrations: [
      plugins: [
        starlightUtils({
            multiSidebar: true
        }),
        // must added after starlightUtils
        starlightBlog({
	    title: "My Blog",
            prefix: BLOG_PREFIX,
	}),
      ],
      components: {
        Sidebar: "./src/components/Sidebar.astro",
      },
      ...
    }),
	...
  ],
});
```

```js
// src/components/Sidebar.astro
---
import MultiSidebar from "@lorenzo_lewis/starlight-utils/components/Sidebar.astro";
import Default from "@astrojs/starlight/components/Sidebar.astro";
const isBlog = Astro.locals.starlightRoute.id.startsWith("blogs");
---

{
	isBlog && (
		<Default {...Astro.locals.starlightRoute}>
			<slot />
		</Default>
	)
}
{
	!isBlog && (
		<MultiSidebar {...Astro.locals.starlightRoute}>
			<slot />
		</MultiSidebar>
	)
}

```

> By default, plugin middleware runs in the order the plugins are added.Set order: "post" to run after all other middleware.If two plugins add middleware with the same order value, the plugin added first will run first.


