### PR TITLE
Fix prev/next labels with `prevNextLinksOrder` set to `chronological` in blog post list

### DIFF
--- a/.changeset/swift-apes-develop.md
+++ b/.changeset/swift-apes-develop.md
@@ -1,0 +1,5 @@
+---
+'starlight-blog': patch
+---
+
+Fixes invalid labels for the prev/next links in the blog post list pages when using the [`prevNextLinksOrder` plugin option](https://starlight-blog-docs.vercel.app/configuration/#prevnextlinksorder) set to `chronological`.

--- a/packages/starlight-blog/components/PrevNextLinks.astro
+++ b/packages/starlight-blog/components/PrevNextLinks.astro
@@ -1,5 +1,6 @@
 ---
 import { LinkCard, CardGrid } from '@astrojs/starlight/components'
+import config from 'virtual:starlight-blog-config'
 
 import type { StarlightBlogLink } from '../libs/content'
 
@@ -16,10 +17,28 @@ const { next, prev } = Astro.props
     <div class="pagination" data-pagefind-ignore>
       <CardGrid>
         {prev && (
-          <LinkCard href={prev.href} rel="prev" title={prev.label ?? Astro.locals.t('starlightBlog.pagination.prev')} />
+          <LinkCard
+            href={prev.href}
+            rel="prev"
+            title={
+              prev.label ??
+              (config.prevNextLinksOrder === 'reverse-chronological'
+                ? Astro.locals.t('starlightBlog.pagination.prev')
+                : Astro.locals.t('starlightBlog.pagination.next'))
+            }
+          />
         )}
         {next && (
-          <LinkCard href={next.href} rel="next" title={next.label ?? Astro.locals.t('starlightBlog.pagination.next')} />
+          <LinkCard
+            href={next.href}
+            rel="next"
+            title={
+              next.label ??
+              (config.prevNextLinksOrder === 'reverse-chronological'
+                ? Astro.locals.t('starlightBlog.pagination.next')
+                : Astro.locals.t('starlightBlog.pagination.prev'))
+            }
+          />
         )}
       </CardGrid>
     </div>


### PR DESCRIPTION
Close #149 