### PR TITLE
Add German missing metrics UI translations

### DIFF
--- a/.changeset/seven-starfishes-hope.md
+++ b/.changeset/seven-starfishes-hope.md
@@ -1,5 +1,0 @@
----
-'starlight-blog': patch
----
-
-Adds German UI translations

--- a/.changeset/seven-starfishes-hope.md
+++ b/.changeset/seven-starfishes-hope.md
@@ -1,0 +1,5 @@
+---
+'starlight-blog': patch
+---
+
+Adds German UI translations

--- a/packages/starlight-blog/translations.ts
+++ b/packages/starlight-blog/translations.ts
@@ -68,7 +68,7 @@ export const Translations = {
   de: {
     'starlightBlog.authors.count_one': '{{count}} Beitrag von {{author}}',
     'starlightBlog.authors.count_other': '{{count}} Beiträge von {{author}}',
-    'starlightBlog.metrics.readingTime.minutes': ' - {{count}} Min. Lesezeit',
+    'starlightBlog.metrics.readingTime.minutes': ' - {{count}} min Lesezeit',
     'starlightBlog.metrics.words_one': ' - {{count}} Wort',
     'starlightBlog.metrics.words_other': ' - {{count}} Wörter',
     'starlightBlog.pagination.prev': 'Neuere Beiträge',

--- a/packages/starlight-blog/translations.ts
+++ b/packages/starlight-blog/translations.ts
@@ -68,6 +68,9 @@ export const Translations = {
   de: {
     'starlightBlog.authors.count_one': '{{count}} Beitrag von {{author}}',
     'starlightBlog.authors.count_other': '{{count}} Beiträge von {{author}}',
+    'starlightBlog.metrics.readingTime.minutes': ' - {{count}} Min. Lesezeit',
+    'starlightBlog.metrics.words_one': ' - {{count}} Wort',
+    'starlightBlog.metrics.words_other': ' - {{count}} Wörter',
     'starlightBlog.pagination.prev': 'Neuere Beiträge',
     'starlightBlog.pagination.next': 'Ältere Beiträge',
     'starlightBlog.post.date': '{{date, datetime(dateStyle: medium)}}',


### PR DESCRIPTION
I chose a rather fitting German translation which is not exactly `4 min read`, but rather `4 min reading time` because in German no real good translation for `read` in this context exists.

- [x] Remove changeset