### PR TITLE
fix: restore support for `Infinity` in the `recentPostCount` and `postCount` options

### DIFF
--- a/.changeset/two-rules-swim.md
+++ b/.changeset/two-rules-swim.md
@@ -2,4 +2,4 @@
 'starlight-blog': patch
 ---
 
-Restore support of `Infinity` with `recentPostCount` and `postCount` options
+Fixes a regression in version `0.26.0` preventing to use `Infinity` as a value for the `postCount` and `recentPostCount` configuration options.

--- a/.changeset/two-rules-swim.md
+++ b/.changeset/two-rules-swim.md
@@ -1,0 +1,5 @@
+---
+'starlight-blog': patch
+---
+
+Restore support of `Infinity` with `recentPostCount` and `postCount` options

--- a/packages/starlight-blog/libs/config.ts
+++ b/packages/starlight-blog/libs/config.ts
@@ -69,11 +69,17 @@ const configSchema = z
     /**
      * The number of blog posts to display per page in the blog post list.
      */
-    postCount: z.number().min(1).or(z.literal(Infinity)).default(5).transform(infinityToMax),
+    postCount: z
+      .union([z.number().min(1), z.literal(Infinity)])
+      .default(5)
+      .transform(infinityToMax),
     /**
      * The number of recent blog posts to display in the sidebar.
      */
-    recentPostCount: z.number().min(1).or(z.literal(Infinity)).default(10).transform(infinityToMax),
+    recentPostCount: z
+      .union([z.number().min(1), z.literal(Infinity)])
+      .default(10)
+      .transform(infinityToMax),
     /**
      * Defines whether or not an RSS feed should be generated for the blog.
      *

--- a/packages/starlight-blog/libs/config.ts
+++ b/packages/starlight-blog/libs/config.ts
@@ -69,11 +69,11 @@ const configSchema = z
     /**
      * The number of blog posts to display per page in the blog post list.
      */
-    postCount: z.number().min(1).default(5).transform(infinityToMax),
+    postCount: z.number().min(1).or(z.literal(Infinity)).default(5).transform(infinityToMax),
     /**
      * The number of recent blog posts to display in the sidebar.
      */
-    recentPostCount: z.number().min(1).default(10).transform(infinityToMax),
+    recentPostCount: z.number().min(1).or(z.literal(Infinity)).default(10).transform(infinityToMax),
     /**
      * Defines whether or not an RSS feed should be generated for the blog.
      *

--- a/packages/starlight-blog/tests/unit/basics/config.test.ts
+++ b/packages/starlight-blog/tests/unit/basics/config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+
+import { validateConfig } from '../../../libs/config'
+
+describe('counts', () => {
+  test('uses default count values', () => {
+    const config = validateConfig({})
+
+    expect(config.postCount).toBe(5)
+    expect(config.recentPostCount).toBe(10)
+  })
+
+  test('supports custom count values', () => {
+    const config = validateConfig({ postCount: 3, recentPostCount: 7 })
+
+    expect(config.postCount).toBe(3)
+    expect(config.recentPostCount).toBe(7)
+  })
+
+  test('supports `Infinity` for count values', () => {
+    const config = validateConfig({ postCount: Infinity, recentPostCount: Infinity })
+
+    expect(config.postCount).toBeTypeOf('number')
+    expect(config.recentPostCount).toBeTypeOf('number')
+  })
+
+  test('errors with less than 1 for count values', () => {
+    expect(() => validateConfig({ postCount: 0, recentPostCount: -3 })).toThrowErrorMatchingInlineSnapshot(`
+      [AstroUserError: Invalid starlight-blog configuration:
+
+      ✖ Too small: expected number to be >=1
+        → at postCount
+      ✖ Too small: expected number to be >=1
+        → at recentPostCount
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
**Describe the pull request**

This PR restores support for `Infinity` in the `recentPostCount` and `postCount` options.

**Why**

Spotted during the migration to Astro v6 at https://github.com/Open-reSource/openresource.dev/pull/1559#discussion_r2926320262.

Without changing my Starlight Blog config, I had the following error:

```
8:35:23 Configuration file updated. Restarting...
[astro] Unable to load your Astro config

18:35:23 [ERROR] [config] [AstroUserError] Invalid starlight-blog configuration:

✖ Invalid input: expected number, received number
  → at postCount

  Hint:
    See the error report above for more informations.
    
    If you believe this is a bug, please file an issue at https://github.com/HiDeoo/starlight-blog/issues/new/choose
  Stack trace:
    at validateConfig (/Users/ju/open-reSource/openresource.dev/node_modules/starlight-blog/libs/config.ts:98:11)
    at eval (/Users/ju/open-reSource/openresource.dev/astro.config.mjs:42:18)
    [...] See full stack trace in the browser, or rerun with --verbose.

18:35:23 [ERROR] Continuing with previous valid configuration
```

This is easily reproducible on the `main` branch of this repo by applying the following change:

```diff
diff --git a/docs/astro.config.mjs b/docs/astro.config.mjs
index 5e3f40d..f94f87e 100644
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
       ],
       plugins: [
         starlightBlog({
+          postCount: Infinity,
           title: {
             en: 'Demo Blog',
             fr: 'Blog Démo',
```

**How**

This appears to be due to a change in how `Infinity` is (not) handled by `z.number()` in Zod 4 (see https://github.com/colinhacks/zod/issues/4721). I followed the approach discussed in that issue to implement the fix.

I manually tested with no value, the default value, regular numbers, and Infinity, and everything now seems to work as expected.