### PR TITLE
Removing 'Learn AISO' from showcase list , 

### DIFF
--- a/docs/src/content/docs/resources/showcase.mdx
+++ b/docs/src/content/docs/resources/showcase.mdx
@@ -77,11 +77,6 @@ Starlight Blog is already being used in production. These are some of the sites 
       title: 'Biome',
     },
     {
-      thumbnail: import('../../../assets/showcase/learnaiso.com.png'),
-      href: 'https://learnaiso.com/articles/',
-      title: 'Learn AISO',
-    },
-    {
       thumbnail: import('../../../assets/showcase/actionbase.io.png'),
       href: 'https://actionbase.io/blog/',
       title: 'Actionbase',


### PR DESCRIPTION
Removed 'Learn AISO' showcase entry from the documentation.

This site link is redirecting users to a scamming/false page.