### PR TITLE
Blog author link attributes

### DIFF
--- a/.changeset/lazy-chairs-play.md
+++ b/.changeset/lazy-chairs-play.md
@@ -1,0 +1,5 @@
+---
+'starlight-blog': patch
+---
+
+Add target="_blank" and rel attributes to author links

--- a/packages/starlight-blog/components/Author.astro
+++ b/packages/starlight-blog/components/Author.astro
@@ -28,7 +28,12 @@ const pictureSrc = (
 ) as ImageMetadata | undefined
 ---
 
-<Element href={isLink ? author.url : undefined} class="author">
+<Element
+  href={isLink ? author.url : undefined}
+  rel={isLink ? 'noreferrer noopener' : undefined}
+  target={isLink ? '_blank' : undefined}
+  class="author"
+>
   {pictureSrc && <Image alt={author.name} loading="eager" src={pictureSrc} height={40} width={40} />}
   <div class="text">
     <div class="name">{author.name}</div>


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

Add target="_blank" and rel="noreferrer nopener" attributes to author link for improved security and UX

**Why**

When a user is looking at a blog archive or post and they click an author link, the user is currently taken away from the site/page. We want to leave the user on the site and open a new tab to follow the author link.

**How**

Modified the Author.astro component to add the attributes if the <Element> isLink condition passes.
